### PR TITLE
Remove pre-fix zero for UK National Numbers

### DIFF
--- a/src/Phone.php
+++ b/src/Phone.php
@@ -64,11 +64,11 @@ class Phone
         $this->country = $country;
 
         switch ($country) {
-            case 'gb':
+            case 'GB':
                 $nationalNumber = substr($this->nationalNumber, 1);
 
                 $this->countryCallingCode = (int) str_replace(
-                    ['0', '+', $nationalNumber], '', $this->number
+                    ['+', $nationalNumber], '', $this->number
                 );
                 break;
             default:

--- a/src/Phone.php
+++ b/src/Phone.php
@@ -62,9 +62,21 @@ class Phone
         $this->nationalNumber = preg_replace('/\D/', '', $formattedNumber);
         $this->formattedNumber = $formattedNumber;
         $this->country = $country;
-        $this->countryCallingCode = (int) str_replace(
-            ['+', $this->nationalNumber], '', $this->number
-        );
+
+        switch ($country) {
+            case 'gb':
+                $nationalNumber = substr($this->nationalNumber, 1);
+
+                $this->countryCallingCode = (int) str_replace(
+                    ['0', '+', $nationalNumber], '', $this->number
+                );
+                break;
+            default:
+                $this->countryCallingCode = (int) str_replace(
+                    ['+', $this->nationalNumber], '', $this->number
+                );
+                break;
+        }
     }
 
     /**


### PR DESCRIPTION
Twilio returns GB/UK National Numbers with a prefix zero, then the national version of the `number` this causes the generation of `country_calling_code` to be inaccurate.

My PR fixes that by identifying when it's a `GB` number, and removing the leading zero.