### PR TITLE
feat: remove 5.x support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,8 +6,6 @@ jobs:
         type: string
       laravel:
         type: string
-      symfony:
-        type: string
       phpunit:
         type: string
       coverage:
@@ -21,7 +19,6 @@ jobs:
           name: Install dependencies
           command: |
             composer require "laravel/framework:<<parameters.laravel>>" --no-update -n
-            composer require "symfony/lts:<<parameters.symfony>>" --no-update -n
             composer require "phpunit/phpunit:<<parameters.phpunit>>" --dev --no-update -n
             composer install --no-suggest --prefer-dist -n -o
       - when:
@@ -57,77 +54,15 @@ workflows:
   build:
     jobs:
       - build:
-          name: "php7.1-5.5"
-          php: "7.1"
-          laravel: 5.5.*
-          symfony: ^3.0
-          phpunit: ^6.5
-      - build:
-          name: "php7.1-5.6"
-          php: "7.1"
-          laravel: 5.6.*
-          symfony: ^4.0
-          phpunit: ^7.0
-      - build:
-          name: "php7.1-5.7"
-          php: "7.1"
-          laravel: 5.7.*
-          symfony: ^4.1
-          phpunit: ^7.0
-      - build:
-          name: "php7.1-5.8"
-          php: "7.1"
-          laravel: 5.8.*
-          symfony: ^4.2
-          phpunit: ^7.5
-      - build:
-          name: "php7.2-5.5"
+          name: "php7.2-6"
           php: "7.2"
-          laravel: 5.5.*
-          symfony: ^3.0
-          phpunit: ^6.5
+          laravel: ^6.0
+          phpunit: ^8.3
       - build:
-          name: "php7.2-5.6"
-          php: "7.2"
-          laravel: 5.6.*
-          symfony: ^4.0
-          phpunit: ^7.0
-      - build:
-          name: "php7.2-5.7"
-          php: "7.2"
-          laravel: 5.7.*
-          symfony: ^4.1
-          phpunit: ^7.0
-      - build:
-          name: "php7.2-5.8"
-          php: "7.2"
-          laravel: 5.8.*
-          symfony: ^4.2
-          phpunit: ^7.5
-      - build:
-          name: "php7.3-5.5"
+          name: "php7.3-6"
           php: "7.3"
-          laravel: 5.5.*
-          symfony: ^3.0
-          phpunit: ^6.5
-      - build:
-          name: "php7.3-5.6"
-          php: "7.3"
-          laravel: 5.6.*
-          symfony: ^4.0
-          phpunit: ^7.0
-      - build:
-          name: "php7.3-5.7"
-          php: "7.3"
-          laravel: 5.7.*
-          symfony: ^4.1
-          phpunit: ^7.0
-      - build:
-          name: "php7.3-5.8"
-          php: "7.3"
-          laravel: 5.8.*
-          symfony: ^4.2
-          phpunit: ^7.5
+          laravel: ^6.0
+          phpunit: ^8.3
           coverage: true
       - release:
           context: semantic-release
@@ -135,15 +70,5 @@ workflows:
             branches:
               only: master
           requires:
-            - php7.1-5.5
-            - php7.1-5.6
-            - php7.1-5.7
-            - php7.1-5.8
-            - php7.2-5.5
-            - php7.2-5.6
-            - php7.2-5.7
-            - php7.2-5.8
-            - php7.3-5.5
-            - php7.3-5.6
-            - php7.3-5.7
-            - php7.3-5.8
+            - php7.2-6
+            - php7.3-6

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 
 ## Introduction
 
-A phone validator for Laravel 5.5+ using the free [Twilio Lookup API](https://www.twilio.com/lookup).
+A phone validator for Laravel 6+ using the free [Twilio Lookup API](https://www.twilio.com/lookup).
 
 This package gives developers the ability to validate phone numbers and format phone numbers. All data will be pulled from the Twilio Lookup API.
 

--- a/composer.json
+++ b/composer.json
@@ -21,16 +21,16 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
-        "illuminate/contracts": "5.5.*|5.6.*|5.7.*|5.8.*|6.0.*",
-        "illuminate/container": "5.5.*|5.6.*|5.7.*|5.8.*|6.0.*",
-        "illuminate/support": "5.5.*|5.6.*|5.7.*|5.8.*|6.0.*",
-        "illuminate/validation": "5.5.*|5.6.*|5.7.*|5.8.*|6.0.*",
-        "twilio/sdk": "~5.34.3"
+        "php": "^7.2",
+        "illuminate/contracts": "^6.0",
+        "illuminate/container": "^6.0",
+        "illuminate/support": "^6.0",
+        "illuminate/validation": "^6.0",
+        "twilio/sdk": "^5.0"
     },
     "require-dev": {
-        "graham-campbell/testbench": "^4.0|^5.0",
-        "mockery/mockery": "^1.1.0"
+        "graham-campbell/testbench": "^5.0",
+        "mockery/mockery": "^1.2"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
BREAKING CHANGE: Laravel 5.x support has been removed in favor of Laravel 6.x, as they will be using semantic release going forward. If you require 5.x support, please use `ellisio/laravel-phone@^6.1`.