### PR TITLE
feat: add laravel 7 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,12 +57,22 @@ workflows:
           name: "php7.2-6"
           php: "7.2"
           laravel: ^6.0
-          phpunit: ^8.3
+          phpunit: ^8.0
       - build:
           name: "php7.3-6"
           php: "7.3"
           laravel: ^6.0
-          phpunit: ^8.3
+          phpunit: ^8.0
+      - build:
+          name: "php7.2-7"
+          php: "7.2"
+          laravel: ^7.0
+          phpunit: ^8.5
+      - build:
+          name: "php7.3-7"
+          php: "7.3"
+          laravel: ^7.0
+          phpunit: ^8.5
           coverage: true
       - release:
           context: semantic-release
@@ -72,3 +82,5 @@ workflows:
           requires:
             - php7.2-6
             - php7.3-6
+            - php7.2-7
+            - php7.3-7

--- a/composer.json
+++ b/composer.json
@@ -16,17 +16,17 @@
         {
             "name": "Andrew Ellis",
             "email": "awellis89@gmail.com",
-            "homepage": "https://www.ellisthedev.com",
+            "homepage": "https://twitter.com/ellisthedev",
             "role": "Developer"
         }
     ],
     "require": {
-        "php": "^7.2",
-        "illuminate/contracts": "^6.0",
-        "illuminate/container": "^6.0",
-        "illuminate/support": "^6.0",
-        "illuminate/validation": "^6.0",
-        "twilio/sdk": "^5.0"
+        "php": ">=7.2.5",
+        "illuminate/contracts": "^6.0|^7.0",
+        "illuminate/container": "^6.0|^7.0",
+        "illuminate/support": "^6.0|^7.0",
+        "illuminate/validation": "^6.0|^7.0",
+        "twilio/sdk": "^6.0"
     },
     "require-dev": {
         "graham-campbell/testbench": "^5.0",

--- a/src/Drivers/Twilio.php
+++ b/src/Drivers/Twilio.php
@@ -2,10 +2,10 @@
 
 namespace EllisIO\Phone\Drivers;
 
-use Twilio\Rest\Client;
-use EllisIO\Phone\Phone;
 use EllisIO\Phone\Contracts\Driver;
+use EllisIO\Phone\Phone;
 use Twilio\Exceptions\RestException;
+use Twilio\Rest\Client;
 
 class Twilio implements Driver
 {

--- a/src/PhoneManager.php
+++ b/src/PhoneManager.php
@@ -2,8 +2,8 @@
 
 namespace EllisIO\Phone;
 
-use Illuminate\Support\Manager;
 use EllisIO\Phone\Drivers\Twilio;
+use Illuminate\Support\Manager;
 use Twilio\Rest\Client as TwilioClient;
 
 class PhoneManager extends Manager implements Contracts\Factory

--- a/src/PhoneValidator.php
+++ b/src/PhoneValidator.php
@@ -2,8 +2,8 @@
 
 namespace EllisIO\Phone;
 
-use InvalidArgumentException;
 use EllisIO\Phone\Facades\Phone;
+use InvalidArgumentException;
 
 class PhoneValidator
 {

--- a/tests/Drivers/TwilioTest.php
+++ b/tests/Drivers/TwilioTest.php
@@ -2,9 +2,9 @@
 
 namespace EllisIO\Tests\Phone\Drivers;
 
+use EllisIO\Phone\Facades\Phone as PhoneFacade;
 use EllisIO\Phone\Phone;
 use EllisIO\Tests\Phone\AbstractTestCase;
-use EllisIO\Phone\Facades\Phone as PhoneFacade;
 
 class TwilioTest extends AbstractTestCase
 {

--- a/tests/Facades/PhoneTest.php
+++ b/tests/Facades/PhoneTest.php
@@ -2,10 +2,10 @@
 
 namespace EllisIO\Tests\Phone\Facades;
 
-use EllisIO\Phone\PhoneManager;
 use EllisIO\Phone\Contracts\Factory;
-use EllisIO\Tests\Phone\AbstractTestCase;
 use EllisIO\Phone\Facades\Phone as Facade;
+use EllisIO\Phone\PhoneManager;
+use EllisIO\Tests\Phone\AbstractTestCase;
 use GrahamCampbell\TestBenchCore\FacadeTrait;
 
 class PhoneTest extends AbstractTestCase

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -2,9 +2,9 @@
 
 namespace EllisIO\Tests\Phone;
 
-use InvalidArgumentException;
-use EllisIO\Phone\PhoneManager;
 use EllisIO\Phone\Contracts\Driver;
+use EllisIO\Phone\PhoneManager;
+use InvalidArgumentException;
 
 class FactoryTest extends AbstractTestCase
 {

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -2,8 +2,8 @@
 
 namespace EllisIO\Tests\Phone;
 
-use InvalidArgumentException;
 use Illuminate\Support\Facades\Validator;
+use InvalidArgumentException;
 
 class ValidatorTest extends AbstractTestCase
 {


### PR DESCRIPTION
BREAKING CHANGE: Updated to `twilio/sdk@^6.0`. This may cause your implementation to break. Please refer to their [releases](https://github.com/twilio/twilio-php/releases).